### PR TITLE
Extend program status api

### DIFF
--- a/example.py
+++ b/example.py
@@ -12,7 +12,9 @@ async def main():
     async with VZUG(IP_ADDRESS, USERNAME, PASSWORD) as vzug:
         # Collect the data of the current state
         await vzug.get_device_status()
+        await vzug.get_program_status()
         print("Device details:", vzug.device_status)
+        print("Program details:", vzug.program_status)
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author="Moritz Bützer",
     author_email="moritz@buetzer.bz",
     license="Apache License 2.0",
-    install_requires=["requests"],
+    install_requires=["requests", "yarl"],
     setup_requires=['wheel'],
     packages=find_packages(),
     zip_safe=True,

--- a/vzug/constants.py
+++ b/vzug/constants.py
@@ -1,5 +1,6 @@
 """Constants used by the Python V-ZUG API."""
 import pkg_resources
+from yarl import URL
 
 try:
     __version__ = pkg_resources.get_distribution("setuptools").version
@@ -9,9 +10,11 @@ except Exception:
 TIMEOUT = 10
 
 USER_AGENT = f"PythonVZUG/{__version__}"
-API = "/ai"
+API = URL("/ai")
+API2 = URL("/hh")
 
 DEVICE_STATUS = "getDeviceStatus"
+PROGRAM_STATUS = "getProgram"
 
 # Communication constants
 CONTENT_TYPE_JSON = "application/json"

--- a/vzug/vzug.py
+++ b/vzug/vzug.py
@@ -7,7 +7,8 @@ from yarl import URL
 from . import make_call
 from .constants import (
   API,
-  DEVICE_STATUS,
+  API2,
+  DEVICE_STATUS, PROGRAM_STATUS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,18 +23,31 @@ class VZUG:
         self._password = password
         self._session = session
         self._device_status = None
-        self.uri = URL.build(scheme="http", host=self._host).join(URL(API))
+        self._program_status = None
+        self.uri: URL = URL.build(scheme="http", host=self._host)
+        print(self.uri)
 
     async def get_device_status(self) -> None:
         """Get the details from the devices."""
-        url = URL(self.uri).update_query({'command': DEVICE_STATUS})
+        url = self.uri.join(API).update_query({'command': DEVICE_STATUS})
         response = await make_call(self, uri=url, username=self._username, password=self._password)
         self._device_status = response
+
+    async def get_program_status(self) -> None:
+        """Get information about the currently running program"""
+        url = self.uri.join(API2).update_query({'command': PROGRAM_STATUS})
+        response = await make_call(self, uri=url, username=self._username, password=self._password)
+        self._program_status = response
 
     @property
     def device_status(self) -> str:
         """Return the current device details."""
         return self._device_status
+
+    @property
+    def program_status(self) -> str:
+        """Return the current program details."""
+        return self._program_status
 
     # See "Using Asyncio in Python" by Caleb Hattingh for implementation details.
     async def close(self) -> None:


### PR DESCRIPTION
First of all thanks for providing a Python package! This extends the Python API by another endpoint called `getProgram`. For my oven the resulting return value looks like this:

```
[{"id":5,"name":"Heissluft feucht","status":"active","fastheating":{"set":false},"temp":{"set":150}}]
```

Unfortunately, I couldn't figure out what `ai` and `hh` stand for so I named the latter one `API2` in `constants.py`.
If somebody has a better name, please let me know.

Also, let me know if something is missing before it can be merged. :)